### PR TITLE
로컬에서 커밋로그 안정화를 위해 husky & lint-staged 설정 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# build, lint, test를 차례대로 실행
+npm run build && npm run lint && npm run test

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,7 @@
+{
+  "*.{js,jsx,ts,tsx}": [
+    "eslint --fix",
+    "prettier --write",
+    "jest --findRelatedTests --passWithNoTests"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:watch": "jest --watchAll"
+    "test:watch": "jest --watchAll",
+    "prepare": "husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watchAll",
-    "prepare": "husky"
+    "prepare": "husky",
+    "lint-staged": "lint-staged"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19p7c1MGgMs1vmtebrBeQS6zvr0niUMBTw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=bTKHLPc)
## 연관된 이슈
- DAL-17, DAL-8

## 작업 내용
- 로컬에서 커밋로그 안정화를 위해 husky & lint-staged 설정 추가
- pre-push로 push 전 lint, test, build 검증 수행
- pre-push에 많은 수정이 발생할 수 있다고 판단되어 pre-commit으로 커밋 마다 간단 검증 수행 추가
- pre-commit 시 lint-staged를 이용해서 변경된 파일에만 해당 검사 적용